### PR TITLE
Fix Qwen3-ASR model download: correct HF repo name and add torch deps

### DIFF
--- a/manoasr/cli/utils/constants.py
+++ b/manoasr/cli/utils/constants.py
@@ -34,7 +34,7 @@ MODEL_TYPES = {
     "qwen3-asr": {
         "label": "Qwen3-ASR",
         "server_type": "qwen3_asr",
-        "default_model": "Qwen3-ASR-1_7B-8bit",
+        "default_model": "Qwen3-ASR-1.7B-8bit",
     },
 }
 
@@ -42,13 +42,13 @@ ALLOWED_EXTENSIONS = {".wav", ".mp3", ".ogg", ".webm", ".m4a", ".flac"}
 
 HF_REPO_MAP = {
     "Fun-ASR-Nano-2512-8bit": "mlx-community/Fun-ASR-Nano-2512-8bit",
-    "Qwen3-ASR-1_7B-8bit": "mlx-community/Qwen3-ASR-1_7B-8bit",
+    "Qwen3-ASR-1.7B-8bit": "mlx-community/Qwen3-ASR-1.7B-8bit",
     "fsmn-vad-mlx": "Mininglamp-2718/fsmn-vad-mlx",
 }
 
 MODELSCOPE_REPO_MAP = {
     "Fun-ASR-Nano-2512-8bit": "luosir001/Fun-ASR-Nano-2512-8bit",
-    "Qwen3-ASR-1_7B-8bit": "luosir001/Qwen3-ASR-1_7B-8bit",
+    "Qwen3-ASR-1.7B-8bit": "luosir001/Qwen3-ASR-1_7B-8bit",
     "fsmn-vad-mlx": "Mininglamp2718/fsmn-vad-mlx",
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "modelscope",
     "tqdm",
     "soundfile",
+    "torch",
+    "torchaudio",
 ]
 
 [project.scripts]


### PR DESCRIPTION
- Fix HF_REPO_MAP: Qwen3-ASR-1_7B-8bit → Qwen3-ASR-1.7B-8bit (dot not underscore)
- Add torch and torchaudio to dependencies for FSMN VAD support