### PR TITLE
Persistent torch install and startup health check

### DIFF
--- a/homebrew/mano-asr.rb
+++ b/homebrew/mano-asr.rb
@@ -1,12 +1,12 @@
 class ManoAsr < Formula
   desc "Local speech-to-text service powered by MLX, optimized for Apple Silicon"
   homepage "https://github.com/Mininglamp-AI/mano-asr"
-  url "https://github.com/Mininglamp-AI/mano-asr/archive/refs/tags/v0.1.5.tar.gz"
+  url "https://github.com/Mininglamp-AI/mano-asr/archive/refs/tags/v0.1.6.tar.gz"
   sha256 ""
   license "MIT"
 
   bottle do
-    root_url "https://github.com/Mininglamp-AI/mano-asr/releases/download/v0.1.5"
+    root_url "https://github.com/Mininglamp-AI/mano-asr/releases/download/v0.1.6"
     sha256 cellar: :any_skip_relocation, arm64_tahoe: "ec5fbe2acd69b36053bbd56d8fdfcd644879cb201785641f93988f4b2a7cb39d"
   end
 
@@ -58,6 +58,6 @@ class ManoAsr < Formula
   end
 
   test do
-    assert_match "0.1.5", shell_output("#{bin}/mano-asr --version")
+    assert_match "0.1.6", shell_output("#{bin}/mano-asr --version")
   end
 end

--- a/manoasr/__init__.py
+++ b/manoasr/__init__.py
@@ -1,4 +1,4 @@
 # coding=utf-8
 """mano-asr: 本地语音转写服务"""
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/manoasr/cli/commands/service.py
+++ b/manoasr/cli/commands/service.py
@@ -23,6 +23,7 @@ from manoasr.cli.utils.console import (
 from manoasr.cli.utils.process import (
     get_pid,
     save_pid,
+    remove_pid,
     stop_process,
     is_port_in_use,
     get_port_process,
@@ -172,6 +173,8 @@ def _run_server(config: dict, port: int, debug: bool = False):
     import uvicorn
 
     from manoasr.cli.utils.constants import PROJECT_ROOT
+    from manoasr.cli.utils.torch_deps import add_torch_to_path
+    add_torch_to_path()
 
     sys.path.insert(0, str(PROJECT_ROOT))
 
@@ -227,6 +230,19 @@ def _start_daemon(config: dict, port: int, debug: bool = False):
         )
 
     save_pid(process.pid)
+
+    import time
+    for _ in range(30):
+        time.sleep(0.5)
+        ret = process.poll()
+        if ret is not None:
+            remove_pid()
+            click.echo(error("Service failed to start (process exited)"))
+            click.echo(info("Check logs: mano-asr logs"))
+            raise SystemExit(1)
+        healthy, _ = _check_service_health(port, timeout=0.5)
+        if healthy:
+            break
 
     model_type_key = config.get("models", {}).get("type", DEFAULT_MODEL_TYPE)
     spec = MODEL_TYPES.get(model_type_key, {})

--- a/manoasr/cli/commands/transcribe.py
+++ b/manoasr/cli/commands/transcribe.py
@@ -90,6 +90,8 @@ def _transcribe_directly(audio_path: Path, hotwords: str, output_format: str) ->
     config = load_config()
 
     from manoasr.cli.utils.constants import PROJECT_ROOT
+    from manoasr.cli.utils.torch_deps import add_torch_to_path
+    add_torch_to_path()
 
     sys.path.insert(0, str(PROJECT_ROOT))
 

--- a/manoasr/cli/daemon.py
+++ b/manoasr/cli/daemon.py
@@ -28,6 +28,9 @@ def main():
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
+    from manoasr.cli.utils.torch_deps import add_torch_to_path
+    add_torch_to_path()
+
     sys.path.insert(0, str(PROJECT_ROOT))
 
     import server

--- a/manoasr/cli/utils/constants.py
+++ b/manoasr/cli/utils/constants.py
@@ -3,7 +3,7 @@
 
 from pathlib import Path
 
-VERSION = "0.1.5"
+VERSION = "0.1.6"
 
 DEFAULT_PORT = 8787
 

--- a/manoasr/cli/utils/download.py
+++ b/manoasr/cli/utils/download.py
@@ -319,6 +319,9 @@ def ensure_default_models(model_type_key: str) -> tuple[Path, Optional[Path]]:
     vad_path = None
     try:
         vad_path = ensure_model(DEFAULT_VAD_MODEL, is_vad=True)
+        from .torch_deps import ensure_torch
+        if not ensure_torch():
+            click.echo(warning("VAD dependencies not available, VAD may not work"))
     except SystemExit:
         click.echo(warning("VAD model not available, continuing without VAD"))
 

--- a/manoasr/cli/utils/torch_deps.py
+++ b/manoasr/cli/utils/torch_deps.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+"""Manage torch/torchaudio installation in persistent user directory."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+
+from .constants import CONFIG_DIR
+
+TORCH_LIB_DIR = CONFIG_DIR / "lib"
+PYTHON_VERSION_FILE = TORCH_LIB_DIR / ".python_version"
+
+
+def _current_python_version() -> str:
+    return f"{sys.version_info.major}.{sys.version_info.minor}"
+
+
+def _is_torch_installed() -> bool:
+    saved = TORCH_LIB_DIR / ".python_version"
+    if saved.exists():
+        saved_version = saved.read_text().strip()
+        if saved_version != _current_python_version():
+            return False
+
+    original_path = sys.path[:]
+    sys.path.insert(0, str(TORCH_LIB_DIR))
+    try:
+        import importlib
+        importlib.import_module("torch")
+        importlib.import_module("torchaudio")
+        return True
+    except ImportError:
+        return False
+    finally:
+        sys.path[:] = original_path
+
+
+def ensure_torch() -> bool:
+    """Ensure torch and torchaudio are installed. Returns True if available."""
+    if _is_torch_installed():
+        add_torch_to_path()
+        return True
+
+    click.echo("  → Installing VAD dependencies (torch, torchaudio)...")
+    click.echo("    This is a one-time download (~200 MB), please wait...")
+
+    TORCH_LIB_DIR.mkdir(parents=True, exist_ok=True)
+
+    try:
+        subprocess.check_call(
+            [
+                sys.executable, "-m", "pip", "install",
+                "--target", str(TORCH_LIB_DIR),
+                "--upgrade",
+                "torch",
+                "torchaudio",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode() if e.stderr else ""
+        click.echo(f"  ✗ Failed to install torch: {stderr[:200]}")
+        click.echo("    Manual install: pip install --target ~/.mano-asr/lib torch torchaudio")
+        return False
+
+    PYTHON_VERSION_FILE.write_text(_current_python_version())
+
+    add_torch_to_path()
+    click.echo("  ✓ VAD dependencies installed")
+    return True
+
+
+def add_torch_to_path() -> None:
+    """Add the persistent torch lib directory to sys.path if not already present."""
+    lib_str = str(TORCH_LIB_DIR)
+    if lib_str not in sys.path:
+        sys.path.insert(0, lib_str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "manoasr"
-version = "0.1.5"
+version = "0.1.6"
 description = "本地语音转写服务，基于 MLX，针对 Apple Silicon 优化"
 requires-python = ">=3.10"
 dependencies = [
@@ -23,8 +23,6 @@ dependencies = [
     "modelscope",
     "tqdm",
     "soundfile",
-    "torch",
-    "torchaudio",
 ]
 
 [project.scripts]


### PR DESCRIPTION
- Remove torch/torchaudio from pyproject.toml (no longer bundled in bottle)
- Add torch_deps.py: auto-install torch to ~/.mano-asr/lib/ on first VAD use
- Add startup health check: detect daemon crash and report error immediately
- Bump version to 0.1.6