### PR TITLE
Bump version to 0.1.6, fix Qwen3-ASR model name, add post_install hook

### DIFF
--- a/.github/workflows/bottle.yml
+++ b/.github/workflows/bottle.yml
@@ -173,6 +173,11 @@ jobs:
               chmod 0755, bin/"mano-asr"
             end
 
+            def post_install
+              venv = libexec/"venv"
+              system venv/"bin/pip", "install", "--retries", "3", "--timeout", "120", "torch", "torchaudio"
+            end
+
             def caveats
               <<~EOS
                 mano-asr installed successfully!

--- a/homebrew/mano-asr.rb
+++ b/homebrew/mano-asr.rb
@@ -1,12 +1,12 @@
 class ManoAsr < Formula
   desc "Local speech-to-text service powered by MLX, optimized for Apple Silicon"
   homepage "https://github.com/Mininglamp-AI/mano-asr"
-  url "https://github.com/Mininglamp-AI/mano-asr/archive/refs/tags/v0.1.4.tar.gz"
+  url "https://github.com/Mininglamp-AI/mano-asr/archive/refs/tags/v0.1.6.tar.gz"
   sha256 ""
   license "MIT"
 
   bottle do
-    root_url "https://github.com/Mininglamp-AI/mano-asr/releases/download/v0.1.4"
+    root_url "https://github.com/Mininglamp-AI/mano-asr/releases/download/v0.1.6"
     sha256 cellar: :any_skip_relocation, arm64_tahoe: "ec5fbe2acd69b36053bbd56d8fdfcd644879cb201785641f93988f4b2a7cb39d"
   end
 
@@ -38,6 +38,11 @@ class ManoAsr < Formula
     chmod 0755, bin/"mano-asr"
   end
 
+  def post_install
+    venv = libexec/"venv"
+    system venv/"bin/pip", "install", "--retries", "3", "--timeout", "120", "torch", "torchaudio"
+  end
+
   def caveats
     <<~EOS
       mano-asr installed successfully!
@@ -58,6 +63,6 @@ class ManoAsr < Formula
   end
 
   test do
-    assert_match "0.1.4", shell_output("#{bin}/mano-asr --version")
+    assert_match "0.1.6", shell_output("#{bin}/mano-asr --version")
   end
 end

--- a/manoasr/__init__.py
+++ b/manoasr/__init__.py
@@ -1,4 +1,4 @@
 # coding=utf-8
 """mano-asr: 本地语音转写服务"""
 
-__version__ = "0.1.4"
+__version__ = "0.1.6"

--- a/manoasr/cli/commands/service.py
+++ b/manoasr/cli/commands/service.py
@@ -23,6 +23,7 @@ from manoasr.cli.utils.console import (
 from manoasr.cli.utils.process import (
     get_pid,
     save_pid,
+    remove_pid,
     stop_process,
     is_port_in_use,
     get_port_process,

--- a/manoasr/cli/utils/constants.py
+++ b/manoasr/cli/utils/constants.py
@@ -3,7 +3,7 @@
 
 from pathlib import Path
 
-VERSION = "0.1.4"
+VERSION = "0.1.6"
 
 DEFAULT_PORT = 8787
 
@@ -34,7 +34,7 @@ MODEL_TYPES = {
     "qwen3-asr": {
         "label": "Qwen3-ASR",
         "server_type": "qwen3_asr",
-        "default_model": "Qwen3-ASR-1_7B-8bit",
+        "default_model": "Qwen3-ASR-1.7B-8bit",
     },
 }
 
@@ -42,13 +42,13 @@ ALLOWED_EXTENSIONS = {".wav", ".mp3", ".ogg", ".webm", ".m4a", ".flac"}
 
 HF_REPO_MAP = {
     "Fun-ASR-Nano-2512-8bit": "mlx-community/Fun-ASR-Nano-2512-8bit",
-    "Qwen3-ASR-1_7B-8bit": "mlx-community/Qwen3-ASR-1_7B-8bit",
+    "Qwen3-ASR-1.7B-8bit": "mlx-community/Qwen3-ASR-1.7B-8bit",
     "fsmn-vad-mlx": "Mininglamp-2718/fsmn-vad-mlx",
 }
 
 MODELSCOPE_REPO_MAP = {
     "Fun-ASR-Nano-2512-8bit": "luosir001/Fun-ASR-Nano-2512-8bit",
-    "Qwen3-ASR-1_7B-8bit": "luosir001/Qwen3-ASR-1_7B-8bit",
+    "Qwen3-ASR-1.7B-8bit": "luosir001/Qwen3-ASR-1_7B-8bit",
     "fsmn-vad-mlx": "Mininglamp2718/fsmn-vad-mlx",
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "manoasr"
-version = "0.1.4"
+version = "0.1.6"
 description = "本地语音转写服务，基于 MLX，针对 Apple Silicon 优化"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
- Fix Qwen3-ASR model name: use dot (1.7B) instead of underscore (1_7B) to match HuggingFace repo
- Add post_install hook to install torch/torchaudio via pip in formula and CI template
- Add missing remove_pid import in service.py for daemon health check
- Bump version to 0.1.6