### PR TITLE
Fix transcribe logging lost under uvicorn; bump to 0.1.10

### DIFF
--- a/homebrew/build-bottle.sh
+++ b/homebrew/build-bottle.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION="0.1.9"
+VERSION="0.1.10"
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD_DIR="$PROJECT_DIR/build/bottle"
 

--- a/homebrew/build-release.sh
+++ b/homebrew/build-release.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION="0.1.9"
+VERSION="0.1.10"
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD_DIR="$PROJECT_ROOT/build"
 RELEASE_DIR="$BUILD_DIR/release-v$VERSION"

--- a/homebrew/test-local.sh
+++ b/homebrew/test-local.sh
@@ -53,7 +53,7 @@ FAIL=0
 
 # 版本检查
 VERSION_OUTPUT=$(mano-asr --version 2>&1 || true)
-if echo "$VERSION_OUTPUT" | grep -q "0.1.9"; then
+if echo "$VERSION_OUTPUT" | grep -q "0.1.10"; then
     echo "    ✓ mano-asr --version"
     PASS=$((PASS + 1))
 else

--- a/manoasr/__init__.py
+++ b/manoasr/__init__.py
@@ -1,4 +1,4 @@
 # coding=utf-8
 """mano-asr: 本地语音转写服务"""
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/manoasr/cli/utils/constants.py
+++ b/manoasr/cli/utils/constants.py
@@ -3,7 +3,7 @@
 
 from pathlib import Path
 
-VERSION = "0.1.9"
+VERSION = "0.1.10"
 
 DEFAULT_PORT = 8787
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "manoasr"
-version = "0.1.9"
+version = "0.1.10"
 description = "本地语音转写服务，基于 MLX，针对 Apple Silicon 优化"
 requires-python = ">=3.10"
 dependencies = [

--- a/server.py
+++ b/server.py
@@ -34,8 +34,29 @@ from utils.hotwords_extractor import extract_terms as extract_hotwords_from_cont
 from utils.repetition_detector import check_repetition, has_repetition
 
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
-logger = logging.getLogger(__name__)
+def _setup_logger() -> logging.Logger:
+    """Configure the app logger robustly.
+
+    `logging.basicConfig` is a no-op once the root logger already has handlers,
+    and uvicorn reconfigures logging on startup — so relying on basicConfig made
+    "Transcribe OK" lines silently disappear. Attach our own StreamHandler to
+    this module's logger and disable propagation so it always emits to
+    stdout/stderr (which the daemon redirects to the log file) regardless of
+    uvicorn's setup.
+    """
+    log = logging.getLogger(__name__)
+    log.setLevel(logging.INFO)
+    if not any(isinstance(h, logging.StreamHandler) for h in log.handlers):
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        )
+        log.addHandler(handler)
+    log.propagate = False
+    return log
+
+
+logger = _setup_logger()
 
 MODEL_PATH: Optional[str] = None
 VAD_MODEL_PATH: Optional[str] = None


### PR DESCRIPTION
- server: app logger now uses its own StreamHandler with propagate=False instead of logging.basicConfig, which became a no-op after uvicorn reconfigured root logging — "Transcribe OK" lines were silently dropped. Verified end-to-end: successful transcribe now writes to the log file.
- bump version 0.1.9 -> 0.1.10 (pyproject, __init__, constants, homebrew scripts)